### PR TITLE
Explicitly add maven-compiler-plugin and set compiler to Java 8.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,20 @@
 		</dependency>
 	</dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 	<reporting>
 		<plugins>
 			<plugin>


### PR DESCRIPTION
This PR explicitly adds the maven-compiler-plugin and sets compiler to Java 8.

Without this change the project fails to build under Ubuntu 20.04 with the following errors:
```
[ERROR] error: Source option 5 is no longer supported. Use 6 or later.
[ERROR] error: Target option 1.5 is no longer supported. Use 1.6 or later.
```
There might be a more elegant way of resolving the issue, but this seems to fix it.