### PR TITLE
Fix deprecation warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# maven
+/target/

--- a/pom.xml
+++ b/pom.xml
@@ -34,11 +34,7 @@
             <artifactId>xom</artifactId>
             <version>1.2.5</version>
         </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>2.7</version>
-        </dependency>
+
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
+                    <showDeprecation>true</showDeprecation>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/org/xmlcml/cif/AbstractValueElement.java
+++ b/src/main/java/org/xmlcml/cif/AbstractValueElement.java
@@ -168,7 +168,7 @@ public abstract class AbstractValueElement extends AbstractTextElement {
 		String dd = this.getAttributeValue(CIFAttribute.SU.value);
 		if (dd != null) {
 			try {
-				su = new Double(dd);
+				su = Double.valueOf(dd);
 			} catch (NumberFormatException nfe) {
 				throw new RuntimeException("bad su value: " + nfe);
 			}
@@ -187,7 +187,7 @@ public abstract class AbstractValueElement extends AbstractTextElement {
 			String value = this.getAttributeValue(CIFAttribute.NUMERICVALUE.value);
             if (value != null) {
     			try {
-    				d = new Double(value);
+    				d = Double.valueOf(value);
     			} catch (NumberFormatException nfe) {
     				throw new RuntimeException("expected double: " + nfe);
     			}

--- a/src/main/java/org/xmlcml/cif/CIFParser.java
+++ b/src/main/java/org/xmlcml/cif/CIFParser.java
@@ -16,7 +16,6 @@ import java.util.regex.Pattern;
 
 import nu.xom.Document;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 
@@ -330,34 +329,31 @@ public class CIFParser implements CIFConstants, CIFLocator {
 	public Document parse(BufferedReader bufferedReader) throws CIFException,
 	IOException {
 		Document document = null;
-//		try {
-			// read into buffer so we can do some heuristics
-			List<String> lines = readLines(bufferedReader);
-			int retry = MAXTRY;
-			if (debug) {
-				LOG.debug("Lines read: "+lines.size());
-			}
-			while (true) {
-				try {
-					document = parseLines(lines);
-					break;
-				} catch (CIFException e) {
-					e.printStackTrace();
-					System.err.println("CIFException "+e);
-					if (heuristicCorrection) {
-						fixLine(lines, lineNumber-1, e);
-						retry--;
-					} else {
-						throw e;
-					}
-				} 
-				if (retry == 0) {
-					throw new CIFException("Could not fix errors...");
+		// read into buffer so we can do some heuristics
+		List<String> lines = readLines(bufferedReader);
+		int retry = MAXTRY;
+		if (debug) {
+			LOG.debug("Lines read: "+lines.size());
+		}
+		while (true) {
+			try {
+				document = parseLines(lines);
+				break;
+			} catch (CIFException e) {
+				e.printStackTrace();
+				System.err.println("CIFException "+e);
+				if (heuristicCorrection) {
+					fixLine(lines, lineNumber-1, e);
+					retry--;
+				} else {
+					throw e;
 				}
 			}
-//		} finally {
-		IOUtils.closeQuietly(bufferedReader);
-//		}
+			if (retry == 0) {
+				throw new CIFException("Could not fix errors...");
+			}
+		}
+		bufferedReader.close();
 		return document;
 	}
 

--- a/src/main/java/org/xmlcml/cif/CIFUtil.java
+++ b/src/main/java/org/xmlcml/cif/CIFUtil.java
@@ -176,7 +176,7 @@ public class CIFUtil implements CIFConstants {
         }
         su = value.substring(idx + 1, value.length() - 1);
         try {
-            new Double(su);
+            Double.valueOf(su);
         } catch (NumberFormatException nfe) {
             su = null;
         }
@@ -809,8 +809,8 @@ public class CIFUtil implements CIFConstants {
 				try {
 					values = new double[2];
 					sv = value.substring(0, idx0);
-					values[0] = new Double(sv);
-					values[1] = new Double(value.substring(idx0+1, idx1));
+					values[0] = Double.parseDouble(sv);
+					values[1] = Double.parseDouble(value.substring(idx0+1, idx1));
 				} catch (NumberFormatException e) {
 					throw new RuntimeException("cannot parse as value(su): "+e);
 				}
@@ -821,7 +821,7 @@ public class CIFUtil implements CIFConstants {
 				}
 			} else {
 				try {
-					double d = new Double(value);
+					double d = Double.parseDouble(value);
 					values = new double[2];
 					values[0] = d;
 					values[1] =0;

--- a/src/test/java/org/xmlcml/cif/CIFDataBlockTest.java
+++ b/src/test/java/org/xmlcml/cif/CIFDataBlockTest.java
@@ -6,8 +6,7 @@ import java.io.StringWriter;
 import java.net.URISyntaxException;
 import java.util.List;
 
-import junit.framework.Assert;
-
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/src/test/java/org/xmlcml/cif/CIFTest.java
+++ b/src/test/java/org/xmlcml/cif/CIFTest.java
@@ -8,10 +8,10 @@ import java.io.Writer;
 import java.net.URISyntaxException;
 import java.util.List;
 
-import junit.framework.Assert;
 import nu.xom.Builder;
 import nu.xom.Document;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;

--- a/src/test/java/org/xmlcml/cif/CIFTestBase.java
+++ b/src/test/java/org/xmlcml/cif/CIFTestBase.java
@@ -4,12 +4,12 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 
-import junit.framework.Assert;
 import nu.xom.Document;
 import nu.xom.Element;
 import nu.xom.canonical.Canonicalizer;
 
 import org.apache.log4j.Logger;
+import org.junit.Assert;
 import org.junit.Before;
 
 /**


### PR DESCRIPTION
This PR fixes several deprecation warnings that appear while compiling under Java 8 and Java 11.

The changes are straightforward, except, maybe, for the removal of `IOUtils.closeQuietly()`. It seems that `bufferedReader.close()` is a sufficient replacement, but it may potentially throw an IOException (which was already specified in the `parse()` method signature). Please let me know if the previous behaviour should be restored.